### PR TITLE
Allow the screen to be moved to a different monitor in a reverse direction

### DIFF
--- a/MiroWindowsManager.spoon/init.lua
+++ b/MiroWindowsManager.spoon/init.lua
@@ -120,13 +120,17 @@ function obj:_nextFullScreenStep()
   end
 end
 
-function obj:_moveNextScreenStep()
+function obj:_moveScreenStep(direction)
   if hs.window.focusedWindow() then
     local win = hs.window.frontmostWindow()
     local id = win:id()
     local screen = win:screen()
-
-    win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true)
+    
+    if (direction == "next") then
+      win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true)
+    elseif (direction == "previous") then
+      win:move(win:frame():toUnitRect(screen:frame()), screen:previous(), true)
+    end
   end
 end
 
@@ -237,7 +241,11 @@ function obj:bindHotkeys(mapping)
   end)
 
   hs.hotkey.bind(mapping.nextscreen[1], mapping.nextscreen[2], function ()
-    self:_moveNextScreenStep()
+    self:_moveScreenStep("next")
+  end)
+
+  hs.hotkey.bind(mapping.previousscreen[1], mapping.previousscreen[2], function ()
+    self:_moveScreenStep("previous")
   end)
 
 end

--- a/MiroWindowsManager.spoon/init.lua
+++ b/MiroWindowsManager.spoon/init.lua
@@ -126,7 +126,7 @@ function obj:_moveNextScreenStep()
     local id = win:id()
     local screen = win:screen()
 
-    win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true, 0)
+    win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true)
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ spoon.MiroWindowsManager:bindHotkeys({
   down = {hyper, "down"},
   left = {hyper, "left"},
   fullscreen = {hyper, "f"},
-  nextscreen = {hyper, "n"}
+  nextscreen = {hyper, "n"},
+  previousscreen = {hyper, "p"}
 })
 ```
 
@@ -75,9 +76,10 @@ As the other shortcuts, `hyper` + `f` can be pressed multiple times to obtain a 
 
 ### Move to other display
 
- - `hyper` + `n`: move to other monitor.
+ - `hyper` + `n`: move to next monitor.
+ - `hyper` + `p`: move to previous monitor.
 
- Hitting that shortcut multiple times will rotate between the number of monitors
+ Hitting the shortcuts multiple times will rotate between the number of monitors
 
 ## Animations
 


### PR DESCRIPTION
Originally, the `nextscreen` binding can only move a screen to the next monitor in one direction only. For people with 3 or more monitors, this can be an annoyance when a screen is moved past their "intended" monitor, since they need to go through all the other monitors again. 

This tiny PR adds a new "previousscreen" binding to support the moving of a screen in a reverse direction.

**Changes:**
- Remove the hardcoded animation duration on `_moveNextScreenStep`
- Rename `_moveNextScreenStep` function to `_moveScreenStep` and add a `direction` argument
- Add `previousscreen` key binding
- Add shortcut and description to README.md