### PR TITLE
Exit fullscreen before every action

### DIFF
--- a/MiroWindowsManager.spoon/init.lua
+++ b/MiroWindowsManager.spoon/init.lua
@@ -132,11 +132,14 @@ end
 function obj:_moveNextScreenStep()
   if hs.window.focusedWindow() then
     local win = hs.window.frontmostWindow()
-    self:_exitFullScreen(win)
     local id = win:id()
     local screen = win:screen()
-
-    win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true, 0)
+    if win:isFullScreen() then
+      win:setFullScreen(false)
+      win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true, 1)
+    else
+      win:move(win:frame():toUnitRect(screen:frame()), screen:next(), true, 0)
+    end
   end
 end
 

--- a/MiroWindowsManager.spoon/init.lua
+++ b/MiroWindowsManager.spoon/init.lua
@@ -1,6 +1,6 @@
 -- Copyright (c) 2018 Miro Mannino
--- Permission is hereby granted, free of charge, to any person obtaining a copy of this 
--- software and associated documentation files (the "Software"), to deal in the Software 
+-- Permission is hereby granted, free of charge, to any person obtaining a copy of this
+-- software and associated documentation files (the "Software"), to deal in the Software
 -- without restriction, including without limitation the rights to use, copy, modify, merge,
 -- publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
 -- to whom the Software is furnished to do so, subject to the following conditions:
@@ -8,17 +8,17 @@
 -- The above copyright notice and this permission notice shall be included in all copies
 -- or substantial portions of the Software.
 --
--- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
--- INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+-- INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
 -- PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
--- FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR 
--- OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+-- FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+-- OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 -- DEALINGS IN THE SOFTWARE.
 
 --- === MiroWindowsManager ===
 ---
 --- With this script you will be able to move the window in halves and in corners using your keyboard and mainly using arrows. You would also be able to resize them by thirds, quarters, or halves.
---- 
+---
 --- Official homepage for more info and documentation: [https://github.com/miromannino/miro-windows-manager](https://github.com/miromannino/miro-windows-manager)
 ---
 --- Download: [https://github.com/miromannino/miro-windows-manager/raw/master/MiroWindowsManager.spoon.zip](https://github.com/miromannino/miro-windows-manager/raw/master/MiroWindowsManager.spoon.zip)
@@ -36,14 +36,14 @@ obj.license = "MIT - https://opensource.org/licenses/MIT"
 
 --- MiroWindowsManager.sizes
 --- Variable
---- The sizes that the window can have. 
+--- The sizes that the window can have.
 --- The sizes are expressed as dividend of the entire screen's size.
 --- For example `{2, 3, 3/2}` means that it can be 1/2, 1/3 and 2/3 of the total screen's size
 obj.sizes = {2, 3, 3/2}
 
 --- MiroWindowsManager.fullScreenSizes
 --- Variable
---- The sizes that the window can have in full-screen. 
+--- The sizes that the window can have in full-screen.
 --- The sizes are expressed as dividend of the entire screen's size.
 --- For example `{1, 4/3, 2}` means that it can be 1/1 (hence full screen), 3/4 and 1/2 of the total screen's size
 obj.fullScreenSizes = {1, 4/3, 2}
@@ -61,12 +61,20 @@ obj._pressed = {
   right = false
 }
 
+function obj:_exitFullScreen(win)
+  local win = win or hs.window.focusedWindow()
+  if win:isFullScreen() then
+    win:setFullScreen(false)
+  end
+end
+
 function obj:_nextStep(dim, offs, cb)
   if hs.window.focusedWindow() then
+    local win = hs.window.frontmostWindow()
+    self:_exitFullScreen(win)
     local axis = dim == 'w' and 'x' or 'y'
     local oppDim = dim == 'w' and 'h' or 'w'
     local oppAxis = dim == 'w' and 'y' or 'x'
-    local win = hs.window.frontmostWindow()
     local id = win:id()
     local screen = win:screen()
 
@@ -95,6 +103,7 @@ end
 function obj:_nextFullScreenStep()
   if hs.window.focusedWindow() then
     local win = hs.window.frontmostWindow()
+    self:_exitFullScreen(win)
     local id = win:id()
     local screen = win:screen()
 
@@ -102,7 +111,7 @@ function obj:_nextFullScreenStep()
 
     local nextSize = self.fullScreenSizes[1]
     for i=1,#self.fullScreenSizes do
-      if cell.w == self.GRID.w / self.fullScreenSizes[i] and 
+      if cell.w == self.GRID.w / self.fullScreenSizes[i] and
          cell.h == self.GRID.h / self.fullScreenSizes[i] and
          cell.x == (self.GRID.w - self.GRID.w / self.fullScreenSizes[i]) / 2 and
          cell.y == (self.GRID.h - self.GRID.h / self.fullScreenSizes[i]) / 2 then
@@ -123,6 +132,7 @@ end
 function obj:_moveNextScreenStep()
   if hs.window.focusedWindow() then
     local win = hs.window.frontmostWindow()
+    self:_exitFullScreen(win)
     local id = win:id()
     local screen = win:screen()
 
@@ -133,13 +143,14 @@ end
 function obj:_fullDimension(dim)
   if hs.window.focusedWindow() then
     local win = hs.window.frontmostWindow()
+    self:_exitFullScreen(win)
     local id = win:id()
     local screen = win:screen()
     cell = hs.grid.get(win, screen)
 
     if (dim == 'x') then
       cell = '0,0 ' .. self.GRID.w .. 'x' .. self.GRID.h
-    else  
+    else
       cell[dim] = self.GRID[dim]
       cell[dim == 'w' and 'x' or 'y'] = 0
     end
@@ -178,7 +189,7 @@ function obj:bindHotkeys(mapping)
 
   hs.hotkey.bind(mapping.down[1], mapping.down[2], function ()
     self._pressed.down = true
-    if self._pressed.up then 
+    if self._pressed.up then
       self:_fullDimension('h')
     else
       self:_nextStep('h', true, function (cell, nextSize)
@@ -186,13 +197,13 @@ function obj:bindHotkeys(mapping)
         cell.h = self.GRID.h / nextSize
       end)
     end
-  end, function () 
+  end, function ()
     self._pressed.down = false
   end)
 
   hs.hotkey.bind(mapping.right[1], mapping.right[2], function ()
     self._pressed.right = true
-    if self._pressed.left then 
+    if self._pressed.left then
       self:_fullDimension('w')
     else
       self:_nextStep('w', true, function (cell, nextSize)
@@ -200,13 +211,13 @@ function obj:bindHotkeys(mapping)
         cell.w = self.GRID.w / nextSize
       end)
     end
-  end, function () 
+  end, function ()
     self._pressed.right = false
   end)
 
   hs.hotkey.bind(mapping.left[1], mapping.left[2], function ()
     self._pressed.left = true
-    if self._pressed.right then 
+    if self._pressed.right then
       self:_fullDimension('w')
     else
       self:_nextStep('w', false, function (cell, nextSize)
@@ -214,13 +225,13 @@ function obj:bindHotkeys(mapping)
         cell.w = self.GRID.w / nextSize
       end)
     end
-  end, function () 
+  end, function ()
     self._pressed.left = false
   end)
 
   hs.hotkey.bind(mapping.up[1], mapping.up[2], function ()
     self._pressed.up = true
-    if self._pressed.down then 
+    if self._pressed.down then
         self:_fullDimension('h')
     else
       self:_nextStep('h', false, function (cell, nextSize)
@@ -228,7 +239,7 @@ function obj:bindHotkeys(mapping)
         cell.h = self.GRID.h / nextSize
       end)
     end
-  end, function () 
+  end, function ()
     self._pressed.up = false
   end)
 


### PR DESCRIPTION
Miro does not work when a window is fullscreen (press control command F or click green button in top left to enter fullscreen). 
<img width="335" alt="image" src="https://user-images.githubusercontent.com/13444106/201187358-0a513137-d29c-4dba-ad9c-3656b888343d.png">
My solution is to exit fullscreen before every action that Miro takes:
```lua
function obj:_exitFullScreen(win)
  local win = win or hs.window.focusedWindow()
  if win:isFullScreen() then
    win:setFullScreen(false)
  end
end
```